### PR TITLE
fix: avoid premature exit in flight search route

### DIFF
--- a/src/domains/flights/routes.js
+++ b/src/domains/flights/routes.js
@@ -192,10 +192,12 @@ router.post("/flightOffersSearch", async (req, res) => {
         associatedAdultId: 1,
       };
     }
-    if (flightSearch[0].departureDateTimeRange.length < 2) return true; // Skip validation for one-way flights
-    if (flightSearch?.[1]?.departureDateTimeRange) {
+    // Only validate return date for round trips
+    if (flightSearch.length > 1 && flightSearch[1]?.departureDateTimeRange) {
       const firstDeparture = new Date(flightSearch[0].departureDateTimeRange);
-      const secondDeparture = new Date(flightSearch[1].departureDateTimeRange);
+      const secondDeparture = new Date(
+        flightSearch[1].departureDateTimeRange
+      );
       if (secondDeparture < firstDeparture) {
         throw new Error(
           "Return flight date must be after outbound flight date."


### PR DESCRIPTION
## Summary
- prevent flight search from returning early on one-way trips

## Testing
- `npm test` *(fails: Error: no test specified)*

------
https://chatgpt.com/codex/tasks/task_e_68c5f886be64832db0e6f628342218d8