### PR TITLE
Improve SMTP connection reliability on Render

### DIFF
--- a/src/util/sendMail.js
+++ b/src/util/sendMail.js
@@ -1,18 +1,26 @@
 // .Env config
 require("dotenv").config();
+const dns = require("dns");
 const nodemailer = require("nodemailer");
-const smtpTransport = require("nodemailer-smtp-transport");
+
+// Render instances sometimes default to IPv6 first which Gmail does not
+// consistently accept for SMTP. Prioritise IPv4 lookups to avoid ENETUNREACH
+// errors when establishing the SMTP connection.
+dns.setDefaultResultOrder?.("ipv4first");
 const { AUTH_EMAIL_NO_REPLY, AUTH_PASS_NO_REPLY } = process.env;
-let transporter = nodemailer.createTransport(
-  smtpTransport({
-    service: "gmail",
-    host: "smtp.gmail.com",
-    auth: {
-      user: AUTH_EMAIL_NO_REPLY,
-      pass: AUTH_PASS_NO_REPLY,
-    },
-  })
-);
+const transporter = nodemailer.createTransport({
+  host: "smtp.gmail.com",
+  port: 587,
+  secure: false,
+  requireTLS: true,
+  connectionTimeout: 15000,
+  greetingTimeout: 10000,
+  socketTimeout: 15000,
+  auth: {
+    user: AUTH_EMAIL_NO_REPLY,
+    pass: AUTH_PASS_NO_REPLY,
+  },
+});
 
 transporter.verify((error, success) => {
   if (error) {


### PR DESCRIPTION
## Summary
- prioritise IPv4 DNS results to avoid IPv6 SMTP connection failures on Render
- configure Nodemailer directly with Gmail's STARTTLS settings and explicit timeouts

## Testing
- not run


------
https://chatgpt.com/codex/tasks/task_e_68e639b84c40832da3f328f955e132e5